### PR TITLE
SEO: Mention "Centre Vie en Yoga" and "Grenoble" in pages' description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ author:
 email: centre.vie.en.yoga@free.fr
 phone:
   landline: 04.76.71.63.07
+  mobile: 06.18.10.81.34
 description: >- # this means to ignore newlines until "baseurl:"
   Vie-en-Yoga.com est le site officiel de Centre Vie en Yoga, fondé par Ora
   Josey-Hay, afin :

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ author:
   name: Ora Josey-Hay
   url: https://www.vie-en-yoga.com/
 email: centre.vie.en.yoga@free.fr
+phone:
+  landline: 04.76.71.63.07
 description: >- # this means to ignore newlines until "baseurl:"
   Vie-en-Yoga.com est le site officiel de Centre Vie en Yoga, fondé par Ora
   Josey-Hay, afin :

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ phone:
   landline: 04.76.71.63.07
   mobile: 06.18.10.81.34
 description: >- # this means to ignore newlines until "baseurl:"
-  Vie-en-Yoga.com est le site officiel de Centre Vie en Yoga, fondé par Ora
+  Centre Vie en Yoga, Grenoble - Vie-en-Yoga.com est le site officiel de Centre Vie en Yoga, fondé par Ora
   Josey-Hay, afin :
   - de faire connaître le yoga pour l'intégrer dans la vie d'aujourd'hui, comme
     soutien moral, physique et psychique. permettant de mieux faire face aux

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col text-footer-left">30 ans d'enseignement du Yoga</div>
-      <div class="col text-footer-right"><a href="tel:0618108134">06.18.10.81.34</a> | <a href="mailto:centre.vie.en.yoga@free.fr">centre.vie.en.yoga@free.fr</a></div>
+      <div class="col text-footer-right"><a href="tel:0618108134">06.18.10.81.34</a> | <a href="mailto:{{ site.email }}">{{ site.email }}</a></div>
     </div>
   </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col text-footer-left">30 ans d'enseignement du Yoga</div>
-      <div class="col text-footer-right"><a href="tel:0618108134">06.18.10.81.34</a> | <a href="mailto:{{ site.email }}">{{ site.email }}</a></div>
+      <div class="col text-footer-right"><a href="tel:{{ site.phone.mobile | remove: '.' }}">{{ site.phone.mobile }}</a> | <a href="mailto:{{ site.email }}">{{ site.email }}</a></div>
     </div>
   </div>
 </footer>

--- a/bibliotheque.html
+++ b/bibliotheque.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Bibliothèque
-description: Liste des livres mis à disposition aux élèves du Centre de Vie en Yoga.
+description: Centre Vie en Yoga, Grenoble - Liste des livres mis à disposition des élèves.
 permalink: /bibliotheque/
 order: 10
 type: page

--- a/contact.html
+++ b/contact.html
@@ -37,7 +37,7 @@ type: page
       <h5>Téléphone</h5>
       <p>
         Fixe : <a href="tel:{{ site.phone.landline | remove: '.' }}">{{ site.phone.landline }}</a><br />
-        Portable : <a href="tel:0618108134">06.18.10.81.34</a><br />
+        Portable : <a href="tel:{{ site.phone.mobile | remove: '.' }}">{{ site.phone.mobile }}</a><br />
       </p>
 
       <h5>Adresse mail</h5>

--- a/contact.html
+++ b/contact.html
@@ -36,7 +36,7 @@ type: page
 
       <h5>Téléphone</h5>
       <p>
-        Fixe : <a href="tel:0476716307">04.76.71.63.07</a><br />
+        Fixe : <a href="tel:{{ site.phone.landline | remove: '.' }}">{{ site.phone.landline }}</a><br />
         Portable : <a href="tel:0618108134">06.18.10.81.34</a><br />
       </p>
 

--- a/contact.html
+++ b/contact.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Contact & Accès
-description: Accès au Centre de Vie en Yoga, coordonnées (téléphone, email), et renseignements administratifs.
+description: Centre Vie en Yoga, Grenoble - Accès, coordonnées (téléphone, email), et renseignements administratifs.
 permalink: /contact/
 order: 11
 type: page

--- a/contact.html
+++ b/contact.html
@@ -42,7 +42,7 @@ type: page
 
       <h5>Adresse mail</h5>
       <p>
-        <a href="mailto:centre.vie.en.yoga@free.fr">centre.vie.en.yoga@free.fr</a><br />
+        <a href="mailto:{{ site.email }}">{{ site.email }}</a><br />
       </p>
         
       <h5>Administratif</h5>

--- a/cours/contenu.html
+++ b/cours/contenu.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Contenu d'un cours
-description: Contenu d'un cours de yoga. À quel public s'adresse le Yoga. Ressources audio et vidéo sur le Yoga.
+description: Centre Vie en Yoga, Grenoble - Contenu d'un cours de yoga. À quel public s'adresse le Yoga. Ressources audio et vidéo sur le Yoga.
 permalink: /cours/contenu/
 order: 3
 type: subpage

--- a/cours/dates_cours_essai.html
+++ b/cours/dates_cours_essai.html
@@ -25,7 +25,7 @@ type: subpage
         </svg>
         <div>
           Il est <strong>impératif</strong> de nous contacter au préalable pour fixer le jour et l'heure de ce cours d'essai :
-          <a href="tel:0476716307">04.76.71.63.07</a> / <a href="tel:0618108134">06.18.10.81.34</a> / <a href="mailto:{{ site.email }}">{{ site.email }}</a>
+          <a href="tel:{{ site.phone.landline | remove: '.' }}">{{ site.phone.landline }}</a> / <a href="tel:0618108134">06.18.10.81.34</a> / <a href="mailto:{{ site.email }}">{{ site.email }}</a>
         </div>
       </div>
 

--- a/cours/dates_cours_essai.html
+++ b/cours/dates_cours_essai.html
@@ -25,7 +25,7 @@ type: subpage
         </svg>
         <div>
           Il est <strong>impératif</strong> de nous contacter au préalable pour fixer le jour et l'heure de ce cours d'essai :
-          <a href="tel:{{ site.phone.landline | remove: '.' }}">{{ site.phone.landline }}</a> / <a href="tel:0618108134">06.18.10.81.34</a> / <a href="mailto:{{ site.email }}">{{ site.email }}</a>
+          <a href="tel:{{ site.phone.landline | remove: '.' }}">{{ site.phone.landline }}</a> / <a href="tel:{{ site.phone.mobile | remove: '.' }}">{{ site.phone.mobile }}</a> / <a href="mailto:{{ site.email }}">{{ site.email }}</a>
         </div>
       </div>
 

--- a/cours/dates_cours_essai.html
+++ b/cours/dates_cours_essai.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Dates cours d'essai
-description: Dates des cours d'essai gratuits.
+description: Centre Vie en Yoga, Grenoble - Dates des cours d'essai gratuits.
 permalink: /cours/dates-cours-essai/
 order: 4
 type: subpage

--- a/cours/dates_cours_essai.html
+++ b/cours/dates_cours_essai.html
@@ -25,7 +25,7 @@ type: subpage
         </svg>
         <div>
           Il est <strong>impératif</strong> de nous contacter au préalable pour fixer le jour et l'heure de ce cours d'essai :
-          <a href="tel:0476716307">04.76.71.63.07</a> / <a href="tel:0618108134">06.18.10.81.34</a> / <a href="mailto:centre.vie.en.yoga@free.fr">centre.vie.en.yoga@free.fr</a>
+          <a href="tel:0476716307">04.76.71.63.07</a> / <a href="tel:0618108134">06.18.10.81.34</a> / <a href="mailto:{{ site.email }}">{{ site.email }}</a>
         </div>
       </div>
 

--- a/cours/dates_meditation.html
+++ b/cours/dates_meditation.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Dates méditations
-description: Dates des séances de méditation.
+description: Centre Vie en Yoga, Grenoble - Dates des séances de méditation.
 permalink: /cours/dates-meditations/
 order: 5
 type: subpage

--- a/cours/dates_vacances.html
+++ b/cours/dates_vacances.html
@@ -1,7 +1,7 @@
 ---
 layout: default
-description: Dates des vacances scolaires.
 title: Dates vacances
+description: Centre Vie en Yoga, Grenoble - Dates des vacances scolaires.
 permalink: /cours/dates-vacances/
 order: 6
 type: subpage

--- a/cours/index.html
+++ b/cours/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
-description: Planning des cours de Yoga.
 title: Planning des cours 2022-2023
+description: Centre Vie en Yoga, Grenoble - Planning des cours de Yoga.
 permalink: /cours/
 order: 1
 type: subpage

--- a/cours/tarifs.html
+++ b/cours/tarifs.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Tarifs
-description: Tarifs des cours de Yoga.
+description: Centre Vie en Yoga, Grenoble - Tarifs des cours de Yoga.
 permalink: /cours/tarifs/
 order: 2
 type: subpage

--- a/enseignantes.html
+++ b/enseignantes.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Enseignantes
-description: Présentation des enseignantes du Centre de Vie en Yoga.
+description: Centre Vie en Yoga, Grenoble - Présentation des enseignantes.
 permalink: /enseignantes/
 order: 8
 type: page

--- a/stages.html
+++ b/stages.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Stages
-description: Liste des stages, de yoga et autre.
+description: Centre Vie en Yoga, Grenoble - Liste des stages, de yoga et autre.
 permalink: /stages/
 order: 7
 type: page

--- a/yoga.html
+++ b/yoga.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: À propos du Yoga
-description: Le Yoga, ses origines, le Hatha Yoga, le Yoga de l'Énergie, ses bienfaits, et sa pratique en occident.
+description: Centre Vie en Yoga, Grenoble - Le Yoga, ses origines, le Hatha Yoga, le Yoga de l'Énergie, ses bienfaits, et sa pratique en occident.
 permalink: /yoga/
 order: 9
 type: page


### PR DESCRIPTION
Changelog:

1. factorise email and phone numbers, for easier updates in the future.
2. mention "Centre Vie en Yoga" and "Grenoble" in pages' description to try to improve SEO.