### PR TITLE
Fix: offset scroll for anchor links by header's height

### DIFF
--- a/_sass/v1/_layout.scss
+++ b/_sass/v1/_layout.scss
@@ -15,6 +15,12 @@ main > .container {
   }
 }
 
+// Ensure that the header does not hide the title of the section we point to via
+// anchor links (e.g. via the table of content for /yoga/ or /cours/contenu/).
+html {
+  scroll-padding-top: $top;
+}
+
 // Table of content:
 nav[data-toggle="toc"] {
   top: $top;


### PR DESCRIPTION
Before:
<img width="686" alt="image" src="https://user-images.githubusercontent.com/836014/190931472-94d0ea00-8556-46e5-ab57-d4a35959c0cd.png">

After:
<img width="686" alt="image" src="https://user-images.githubusercontent.com/836014/190931456-5a70393f-9e0a-48a1-99a4-15bcf8c3cb81.png">
