### PR TITLE
feat: add support for per-page SEO keywords

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
   {%- endif -%}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="keywords" content="{{ site.keywords | join: ', ' | escape }}">
+  <meta name="keywords" content="{{ page.keywords | default: site.keywords | join: ', ' | escape }}">
   {%- seo -%}
 
   <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/5.2.0/cosmo/bootstrap.min.css" integrity="sha512-QbZE7wIoZ9KJH/ruhziXsxEbMYKqw+PmhlroAdVcqJnoYhmZmU5lWWyCx20RrZpxfeS6NdFV1+KoReUQmNKHcg==" crossorigin="anonymous" referrerpolicy="no-referrer" onerror="this.onerror=null; this.href='{{ "/assets/css/bootstrap.min.css" | relative_url }}';" />


### PR DESCRIPTION
Keywords can now be customised for each page using its "[front matter](https://jekyllrb.com/docs/front-matter/)" header:

#### Before

```yaml
---
layout: default
title: Enseignantes
description: Centre Vie en Yoga, Grenoble - Présentation des enseignantes.
permalink: /enseignantes/
order: 8
type: page
---
```

#### From now on this can be used

```yaml
---
layout: default
title: Enseignantes
description: Centre Vie en Yoga, Grenoble - Présentation des enseignantes.
permalink: /enseignantes/
order: 8
type: page
keywords:
- blah
- yoga
- blahblah
- ora
---
```