### PR TITLE
fix: upgrade GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
+        uses: ruby/setup-ruby@v1.144.2
         with:
           ruby-version: '3.1'
           bundler-cache: true


### PR DESCRIPTION
See also:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Fixes build failures like:
https://github.com/vie-en-yoga/vie-en-yoga.github.io/actions/runs/4471267386

J'ai mis à jour le test automatisé pour les liens mort.
Ce test était basé sur une vieille version de https://github.com/ruby/setup-ruby/ qui arrive en fin de vie.