### PR TITLE
Stages

### DIFF
--- a/cours/video_audio.html
+++ b/cours/video_audio.html
@@ -85,8 +85,9 @@ type: subpage
           MARCHE MEDITATIVE</a></li>
         <li><a href="http://vieenyog.cluster013.ovh.net/video/se_laver_les_mains_meditation_dans_l_action.mp3" title="Cliquer ici pour démarrer la lecture audio" target="_blank">
           SE LAVER LES MAINS - MEDITATION DANS L'ACTION</a></li>
-        <li><a href="http://vieenyog.cluster013.ovh.net/video/meditation_du_masque.mp3" title="Cliquer ici pour démarrer la lecture audio" target="_blank">
+<!--        <li><a href="http://vieenyog.cluster013.ovh.net/video/meditation_du_masque.mp3" title="Cliquer ici pour démarrer la lecture audio" target="_blank">
           MEDITATION SUR LE MASQUE</a></li>
+-->          
       </ul>
 
       <h6 id="audio-pratiques">Pratiques</h6>

--- a/stages.html
+++ b/stages.html
@@ -108,7 +108,7 @@ keywords:
 <!-- --------------------------------------------------------- -->
 <!-- 17 juin : Energie d'été                                   -->
 <!-- --------------------------------------------------------- -->
- 
+<!-- 
       <h5 id="17juin">17 juin : Energie d'été, à Grenoble</h5>
       <h6>Description</h6>
       <p>
@@ -141,7 +141,7 @@ keywords:
        Votre place vous est réservée à la réception du virement (demandez notre RIB) ou du chèque à l’ordre de « Centre Vie en Yoga ».
       </p>
       <br />
-
+-->
 <!-- --------------------------------------------------------- -->
 <!-- 7 au 9 juillet MEAUDRE : LA RESPIRATION                   -->
 <!-- --------------------------------------------------------- -->
@@ -219,7 +219,7 @@ keywords:
        Votre place vous est réservée à la réception du virement (demandez notre RIB) ou des 2 chèques à l’ordre de « Centre Vie en Yoga » et « Arcanson ».
        <br />
        Les chèques ne seront encaissés qu’après le stage. En cas de règlement par virement, seul celui à l’ordre du centre est nécessaire pour la réservation, le paiement de 240 € à Arcanson se fera sur place. 
-       Le stage peut être annulé s’il y a moins de 8 participants.
+<!--       Le stage peut être annulé s’il y a moins de 8 participants.   -->
       </p>
       <br />
 
@@ -301,7 +301,7 @@ keywords:
        Votre place vous est réservée à la réception du virement (demandez notre RIB) ou des 2 chèques à l’ordre de « Centre Vie en Yoga » et « SAS cogite ».
        <br />
        Les chèques ne seront encaissés qu’après le stage. En cas de règlement par virement, seul celui à l’ordre du centre est nécessaire pour la réservation, le paiement de 230 € à SAS Cogite se fera sur place.
-       Le stage peut être annulé s’il y a moins de 8 participants.
+<!--       Le stage peut être annulé s’il y a moins de 8 participants.   -->
       </p>
       <br />
 
@@ -374,10 +374,16 @@ keywords:
        Vous pouvez également remplir un coupon papier (<a href="/assets/pdf/coupon_stage_centre_vie_en_yoga.pdf" target="_blank">ici</a>).
        Votre place vous est réservée à la réception du virement (demandez notre RIB) ou du chèque à l’ordre de « Centre Vie en Yoga ». 
        Le chèque est encaissé après le stage. 
-       Le stage peut être annulé s’il y a moins de 8 participants.
+<!--       Le stage peut être annulé s’il y a moins de 8 participants.   -->
       </p>
-
     </div><!-- end: col -->
+
+    <div class="text-center">
+      <img src="/assets/img/yoga_dans_la_mer.webp" width="300px" alt="Photo d'Ora JOSEF-HAY" class="rond-center-profile-picture" />
+      <br />
+      <h6>BEL ETE</h6>
+    </div>
+
   </div><!-- end: row -->
 </div><!-- end: container -->
 


### PR DESCRIPTION
Suppression du stage énergie d'été, passé.
Retrait de la mention "le stage peut être supprimé si moins de 8 participants". Retrait de la méditation sur le masque