### PR TITLE
Upgrade Continuous Integration (CI) runners' checkout and Ruby actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.144.2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.144.2
         with:
-          ruby-version: '3.1'
+          ruby-version: "3.1"
           bundler-cache: true
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.144.2
+        uses: ruby/setup-ruby@v1.213.0
         with:
           ruby-version: "3.1"
           bundler-cache: true


### PR DESCRIPTION
### Problem

Recent builds seem to have been failing because `ubuntu-latest` now points to Ubuntu 24.04, and the `ruby/setup-ruby@v1.144.2` step currently used seems incompatible with this version of Ubuntu.

See also:  https://github.com/vie-en-yoga/vie-en-yoga.github.io/actions/runs/12913006604

> The current runner (ubuntu-24.04-x64) was detected as self-hosted because the platform does not match a GitHub-hosted runner image (or that image is deprecated and no longer supported).
> In such a case, you should install Ruby in the $RUNNER_TOOL_CACHE yourself, for example using https://github.com/rbenv/ruby-build
> You can take inspiration from this workflow for more details: https://github.com/ruby/ruby-builder/blob/master/.github/workflows/build.yml
> `$ ruby-build 3.1.3 /opt/hostedtoolcache/Ruby/3.1.3/x64`
> Once that completes successfully, mark it as complete with:
> `$ touch /opt/hostedtoolcache/Ruby/3.1.3/x64.complete`
> It is your responsibility to ensure installing Ruby like that is not done in parallel.

### Solution

Upgrade `ruby/setup-ruby` to a newer version.

### Validation

Confirm that CI now passes: https://github.com/vie-en-yoga/vie-en-yoga.github.io/actions/runs/12973542284/job/36182315213