### PR TITLE
chore: upgrade wdm 0.1.1 -> 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
 end
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", "~> 0.2.0", :platforms => [:mingw, :x64_mingw, :mswin]
 
 
 gem "webrick", "~> 1.7"


### PR DESCRIPTION
Possibly a version incompatibility with `wdm` (Windows Directory Monitor) and Jekyll.

Possibly related to: https://github.com/jekyll/jekyll/issues/9660

Aims to fix:

```text
C:\${PROJECT_PARENT_DIR}\vie-en-yoga.github.io>bundle install
[DEPRECATED] Platform :mingw, :x64_mingw, :mswin will be removed in the future. Please use platform :windows instead.
[DEPRECATED] Found x64-mingw32 in lockfile, which is deprecated and will be removed in the future.
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Installing wdm 0.1.1 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/wdm-0.1.1/ext/wdm
C:/Ruby34-x64/bin/ruby.exe extconf.rb
checking for -lkernel32... yes
checking for windows.h... yes
checking for ruby.h... yes
checking for HAVE_RUBY_ENCODING_H... yes
checking for rb_thread_call_without_gvl()... yes
creating Makefile

current directory:
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/wdm-0.1.1/ext/wdm
make DESTDIR\= sitearchdir\=./.gem.20260423-15632-6b9y0y
sitelibdir\=./.gem.20260423-15632-6b9y0y clean

current directory:
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/wdm-0.1.1/ext/wdm
make DESTDIR\= sitearchdir\=./.gem.20260423-15632-6b9y0y
sitelibdir\=./.gem.20260423-15632-6b9y0y
generating wdm_ext-x64-mingw-ucrt.def
compiling entry.c
compiling memory.c
compiling monitor.c
compiling queue.c
compiling rb_change.c
rb_change.c: In function 'extract_absolute_path_from_notification':
rb_change.c:139:5: warning: 'RB_OBJ_TAINT' is deprecated: taintedness turned out
to be a wrong idea. [-Wdeprecated-declarations]
  139 |     OBJ_TAINT(path);
      |     ^~~~~~~~~
In file included from
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rstring.h:30,
from
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/arithmetic/char.h:29,
from
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/arithmetic.h:24,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/ruby.h:28,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby.h:38,
                 from wdm.h:22,
                 from rb_change.c:4:
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/fl_type.h:824:1: note: declared
here
  824 | RB_OBJ_TAINT(VALUE obj)
      | ^~~~~~~~~~~~
compiling rb_monitor.c
rb_monitor.c: In function 'rb_monitor_alloc':
rb_monitor.c:109:5: warning: 'rb_data_object_wrap_warning' is deprecated: by
TypedData [-Wdeprecated-declarations]
109 |     return Data_Wrap_Struct(self, monitor_mark, monitor_free,
wdm_monitor_new());
      |     ^~~~~~
In file included from C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core.h:27,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/ruby.h:29,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby.h:38,
                 from wdm.h:22,
                 from rb_monitor.c:1:
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:293:1: note:
declared here
293 | rb_data_object_wrap_warning(VALUE klass, void *ptr, RUBY_DATA_FUNC mark,
RUBY_DATA_FUNC free)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
rb_monitor.c: In function 'combined_watch':
rb_monitor.c:159:5: warning: 'rb_data_object_get_warning' is deprecated: by
TypedData [-Wdeprecated-declarations]
  159 |     Data_Get_Struct(self, WDM_Monitor, monitor);
      |     ^~~~~~~~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note:
declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
rb_monitor.c: In function 'rb_monitor_run_bang':
rb_monitor.c:470:5: warning: 'rb_data_object_get_warning' is deprecated: by
TypedData [-Wdeprecated-declarations]
  470 |     Data_Get_Struct(self, WDM_Monitor, monitor);
      |     ^~~~~~~~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note:
declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
rb_monitor.c:509:29: error: implicit declaration of function
'rb_thread_call_without_gvl' [-Wimplicit-function-declaration]
509 |         waiting_succeeded = rb_thread_call_without_gvl(wait_for_changes,
monitor->process_event, stop_monitoring, monitor);
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~
rb_monitor.c: In function 'rb_monitor_stop':
rb_monitor.c:538:5: warning: 'rb_data_object_get_warning' is deprecated: by
TypedData [-Wdeprecated-declarations]
  538 |     Data_Get_Struct(self, WDM_Monitor, monitor);
      |     ^~~~~~~~~~~~~~~
C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/core/rdata.h:325:1: note:
declared here
  325 | rb_data_object_get_warning(VALUE obj)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:251: rb_monitor.o] Error 1

make failed, exit code 2

Gem files will remain installed in
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/wdm-0.1.1 for inspection.
Results logged to
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/extensions/x64-mingw-ucrt/3.4.0/wdm-0.1.1/gem_make.out

C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/builder.rb:125:in
'Gem::Ext::Builder.run'
C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/builder.rb:51:in 'block in
Gem::Ext::Builder.make'
  C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/builder.rb:43:in 'Array#each'
C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/builder.rb:43:in
'Gem::Ext::Builder.make'
C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/ext_conf_builder.rb:44:in
'Gem::Ext::ExtConfBuilder.build'
C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/builder.rb:206:in
'Gem::Ext::Builder#build_extension'
C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/builder.rb:240:in 'block in
Gem::Ext::Builder#build_extensions'
  C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/builder.rb:237:in 'Array#each'
C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/ext/builder.rb:237:in
'Gem::Ext::Builder#build_extensions'
C:/Ruby34-x64/lib/ruby/3.4.0/rubygems/installer.rb:844:in
'Gem::Installer#build_extensions'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/rubygems_gem_installer.rb:115:in
'Bundler::RubyGemsGemInstaller#build_extensions'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/rubygems_gem_installer.rb:30:in
'Bundler::RubyGemsGemInstaller#install'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/source/rubygems.rb:217:in
'block in Bundler::Source::Rubygems#install'
  C:/Ruby34-x64/lib/ruby/3.4.0/rubygems.rb:1002:in 'Gem.time'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/source/rubygems.rb:216:in
'Bundler::Source::Rubygems#install'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/installer/gem_installer.rb:54:in
'Bundler::GemInstaller#install'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/installer/gem_installer.rb:17:in
'Bundler::GemInstaller#install_from_spec'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/installer/parallel_installer.rb:133:in
'Bundler::ParallelInstaller#do_install'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/installer/parallel_installer.rb:124:in
'block in Bundler::ParallelInstaller#worker_pool'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/worker.rb:62:in
'Bundler::Worker#apply_func'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/worker.rb:57:in
'block in Bundler::Worker#process_queue'
  <internal:kernel>:168:in 'Kernel#loop'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/worker.rb:54:in
'Bundler::Worker#process_queue'
C:/Users/${USER}/.local/share/gem/ruby/3.4.0/gems/bundler-4.0.6/lib/bundler/worker.rb:90:in
'block (2 levels) in Bundler::Worker#create_threads'

An error occurred while installing wdm (0.1.1), and Bundler cannot continue.

In Gemfile:
  wdm
Could not find wdm-0.1.1 in locally installed gems
Run `bundle install` to install missing gems.

C:\${PROJECT_PARENT_DIR}\vie-en-yoga.github.io>
```